### PR TITLE
Ask before removing preinstalled docker-engine package

### DIFF
--- a/contrib/install-agent.sh
+++ b/contrib/install-agent.sh
@@ -69,7 +69,7 @@ case "$(get_distribution_type)" in
 			echo "!! Failed to install linux-image-extra package. AUFS support (which is recommended) may not be available."
 		echo "-> Installing dockercloud-agent..."
 		echo deb [arch=amd64] http://$REPO/ubuntu/ dockercloud main > /etc/apt/sources.list.d/dockercloud.list
-		apt-get update -qq -o Dir::Etc::sourceparts="/dev/null" -o APT::List-Cleanup=0 -o Dir::Etc::sourcelist="sources.list.d/dockercloud.list" && apt-get install -yq dockercloud-agent
+		apt-get update -qq -o Dir::Etc::sourceparts="/dev/null" -o APT::List-Cleanup=0 -o Dir::Etc::sourcelist="sources.list.d/dockercloud.list" && apt-get install -q dockercloud-agent
 		;;
 	fedora|centos|rhel)
 		echo "-> Adding Docker Cloud's GPG key..."


### PR DESCRIPTION
Fixes #5 

Our managed nodes do not have the `docker-engine` installed so they will run unattended. This will only prompt when run on a host with `docker-engine` already installed.

cc @tifayuki @amegianeg 
